### PR TITLE
Add info section to the game UI

### DIFF
--- a/sudoku.py
+++ b/sudoku.py
@@ -27,7 +27,7 @@ def main():
     presolved_puzzles = Path('puzzle-dataset', 'pre-solved-sudokus.txt')
     line = get_quiz_and_solution_line(str(presolved_puzzles))
     grid, solution = build_puzzle_solution_pair(line)
-    rprint(ui.vertical_split(ui.get_sudoku_grid(grid), ui.explain_coordinate_system()))
+    rprint(ui.split_left_right(ui.get_sudoku_grid(grid), ui.explain_coordinate_system()))
 
     try:
         if prompt_to_continue() == 'q':
@@ -36,7 +36,7 @@ def main():
     except (KeyboardInterrupt, EOFError):
         sys.exit('Goodbye!')
 
-    rprint(ui.vertical_split(ui.get_sudoku_grid(grid), ui.get_game_keys()))
+    rprint(ui.split_up_down(ui.get_sudoku_and_keys(grid), ui.get_info()))
 
     game_key_func = {
         'u': 'undo_move(grid)',
@@ -59,11 +59,11 @@ def main():
                 make_move(location, number, grid)
             except SudokuError as e:
                 ui.clear_screen()
-                rprint(ui.vertical_split(ui.get_sudoku_grid(grid), ui.get_game_keys()))
-                rprint(f'[bold red]{e.error_message}')
+                rprint(ui.split_up_down(ui.get_sudoku_and_keys(grid), ui.get_info(f'[bold red]{e.error_message}')))
                 continue
         ui.clear_screen()
-        rprint(ui.vertical_split(ui.get_sudoku_grid(grid), ui.get_game_keys()))
+
+        rprint(ui.split_up_down(ui.get_sudoku_and_keys(grid), ui.get_info()))
 
 
 def prompt_to_continue() -> str:

--- a/utils/sudoku_utils.py
+++ b/utils/sudoku_utils.py
@@ -29,7 +29,7 @@ def translate_move(coordinate_move: str) -> Tuple[Tuple[int, int], int]:
 
     if not len(coordinate_move) == LEGAL_COORDINATE_LENGTH:
         raise SudokuError(
-            'Coordinate is invalid.\nThe legal format is <number><row number><column letter> or <number><column letter><row number>'
+            'Coordinate is invalid. The legal format is:\n<number><row number><column letter> or\n<number><column letter><row number>'
         )
 
     if not (coordinate_move[0].isdecimal() and 1 <= int(coordinate_move[0]) <= 9):

--- a/utils/ui.py
+++ b/utils/ui.py
@@ -15,6 +15,18 @@ def clear_screen() -> None:
     os.system('cls' if os.name == 'nt' else 'clear')
 
 
+def get_sudoku_and_keys(grid: List[List[str]]) -> Table:
+    """Returns the sudoku grid and the list of possible game keys to enter, side-by-side."""
+    return split_left_right(get_sudoku_grid(grid), get_game_keys(), outer_edge=False)
+
+
+def get_info(message: str = "") -> Table:
+    """Returns the `info` section of the game UI.
+    This section is reserved for errors, and other useful texts.
+    """
+    return split_left_right('info', message, outer_edge=False)
+
+
 def get_game_keys() -> Table:
     """Shows possible keys that the user can press in the game."""
     keys = Table(show_header=False, show_lines=False, title='game keys:', show_edge=False)

--- a/utils/ui.py
+++ b/utils/ui.py
@@ -24,25 +24,25 @@ def get_game_keys() -> Table:
     return keys
 
 
-def vertical_split(left_element, right_element) -> Table:
+def split_left_right(left_element, right_element, outer_edge=True) -> Table:
     """Returns a rich table with the `left_element` on the left of the table,
     and the `right_element` on the right of the table.
     """
-    UI = Table(show_header=False, show_lines=False, box=box.ROUNDED, padding=(0, 1, 0, 1))
-    UI.add_column()
-    UI.add_column()
+    UI = Table(show_header=False, show_edge=outer_edge, box=box.ROUNDED)
+    UI.add_column(no_wrap=True)
+    UI.add_column(no_wrap=True)
     UI.add_row(left_element, right_element)
     return UI
 
 
-def horizontal_split(top_element, bottom_element) -> Table:
+def split_up_down(top_element, bottom_element, outer_edge=True) -> Table:
     """Returns a rich table with the `top_element` at the top of the table,
     and the `bottom_element` at the bottom of the table.
     """
-    UI = Table(show_header=False, show_lines=False, box=box.ROUNDED, padding=(0, 1, 0, 1))
-    UI.add_column()
-    UI.add_row(top_element)
-    UI.add_row(bottom_element)
+    UI = Table(show_header=False, show_edge=outer_edge, box=box.ROUNDED)
+    UI.add_column(no_wrap=True)
+    UI.add_row(top_element, end_section=True)
+    UI.add_row(bottom_element, end_section=True)
     return UI
 
 


### PR DESCRIPTION
An "info" section has been added to the UI to allow for the more-compact
display of error messages, and other useful game information.

**Before:**
![no-info](https://user-images.githubusercontent.com/89351923/223023463-e905d243-7857-47f8-8306-b28b89e10301.gif)

**After:**
![with-info](https://user-images.githubusercontent.com/89351923/223023499-93fca43c-2266-4859-9477-261b04582275.gif)
